### PR TITLE
Fix: Warning during build (#1224)

### DIFF
--- a/po/nl.po.in
+++ b/po/nl.po.in
@@ -2369,7 +2369,7 @@ msgid ""
 "Sorry, we currently do not support maps above 3.8G on Android, please select "
 "a smaller one."
 msgstr ""
-"Kaarten gorter dan 3,8GB zijn momenteel niet ondersteund op Android.\r\n"
+"Kaarten gorter dan 3,8GB zijn momenteel niet ondersteund op Android.\n"
 "Kies a.u.b. een kleinere kaart."
 
 #. Android resource: @strings/map_no_fix

--- a/po/sr.po.in
+++ b/po/sr.po.in
@@ -21,7 +21,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"Language: \n"
+"Language: sr\n"
 "X-Report-Errors: https://translations.launchpad.net/navit/trunk/+pots/navit\n"
 
 msgid "Running from source directory\n"

--- a/po/zh_TW.po.in
+++ b/po/zh_TW.po.in
@@ -15,6 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+"Language: zh_TW\n"
 
 msgid "Running from source directory\n"
 msgstr "自源目錄執行\n"


### PR DESCRIPTION
* Fix: Warning during build

Added "Language: zh_TW\n" to fix warning.

* Fix: Warning during build

Added "sr" in "Language: sr\n" to address warning during build

* Fix: Warning during build

Remove "\r" from "Kaarten gorter dan 3,8GB zijn momenteel niet ondersteund op Android.\r\n" to address warning during build

Thanks for contributing to Navit!
Before opening a pull request on navit, make sure your commit message follows our guidelines:
https://navit.readthedocs.io/en/trunk/development/commit_guidelines.html

and that your code is compliant with out coding style guidelines:
https://navit.readthedocs.io/en/trunk/development/programming_guidelines.html
